### PR TITLE
Only encode ABI methods with both type and name

### DIFF
--- a/src/util/implementsAbi.js
+++ b/src/util/implementsAbi.js
@@ -1,7 +1,9 @@
 import EthjsAbi from "ethjs-abi";
 
 export const abiToSignatures = abi => {
-  return abi.map(method => EthjsAbi.encodeSignature(method).substring(2));
+  return abi
+    .filter(method => method.name && method.type)
+    .map(method => EthjsAbi.encodeSignature(method).substring(2));
 };
 
 export default (abi, bytecode) => {


### PR DESCRIPTION
Fixes https://github.com/hillstreetlabs/parr/issues/67